### PR TITLE
sidejack.bro script load roam.bro from relative path

### DIFF
--- a/sidejack.bro
+++ b/sidejack.bro
@@ -90,7 +90,7 @@ export {
 }
 
 @ifdef(use_aliasing)
-@load roam
+@load ./roam
 @endif
 
 ## Per-cookie state.


### PR DESCRIPTION
I would like to propose loading roam script from relative path. Now I have to have set bro-script directory in BROPATH when I want to use sidejack script.